### PR TITLE
bump dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,24 +1,24 @@
 buildscript {
     ext {
         //general
-        kotlin_version = '1.2.20'
+        kotlin_version = '1.2.51'
 
         junit_version = "4.12"
 
         //mnid module
         spongycastle_version = '1.58.0.0'
-        kethereum_version = "0.36"
+        kethereum_version = "0.53"
 
         //demo app
-        gradle_tools_version = "3.0.1"
+        gradle_tools_version = "3.1.3"
 
-        build_tools_version = "27.0.2"
+        build_tools_version = "27.0.3"
         compile_sdk_version = 27
         target_sdk_version = compile_sdk_version
         min_sdk_version = 19
 
-        support_lib_version = "27.0.2"
-        constraint_layout_version = "1.0.2"
+        support_lib_version = "27.1.1"
+        constraint_layout_version = "1.1.2"
 
         test_runner_version = "1.0.1"
         espresso_version = "3.0.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/mnid/build.gradle
+++ b/mnid/build.gradle
@@ -4,10 +4,9 @@ apply plugin: "maven"
 apply plugin: "java-library"
 
 dependencies {
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     compile "com.madgag.spongycastle:prov:$spongycastle_version"
-    compile "com.github.walleth:kethereum:$kethereum_version"
-
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "com.github.walleth.kethereum:base58:$kethereum_version"
 
     testCompile "junit:junit:$junit_version"
 }


### PR DESCRIPTION
... and greatly reduce library footprint by only including the `base58` lib from the [kethereum](https://github.com/walleth/kethereum) project