### PR TITLE
[Support] simplify imports and interface

### DIFF
--- a/mnid/src/main/java/me/uport/mnid/Account.kt
+++ b/mnid/src/main/java/me/uport/mnid/Account.kt
@@ -1,5 +1,6 @@
 package me.uport.mnid
 
+import org.komputing.khex.extensions.clean0xPrefix
 import org.komputing.khex.extensions.toHexString
 
 /**

--- a/mnid/src/main/java/me/uport/mnid/Account.kt
+++ b/mnid/src/main/java/me/uport/mnid/Account.kt
@@ -34,7 +34,7 @@ data class Account internal constructor(val network: String, val address: String
         }
     }
 
-    constructor(network: ByteArray, address: ByteArray) : this(
+    internal constructor(network: ByteArray, address: ByteArray) : this(
         network.toHexString(),
         address.toHexString()
     )

--- a/mnid/src/main/java/me/uport/mnid/HexFun.kt
+++ b/mnid/src/main/java/me/uport/mnid/HexFun.kt
@@ -1,7 +1,7 @@
 package me.uport.mnid
 
 fun String.hexToByteArrayLenient(): ByteArray {
-    val cleanInput = if (startsWith("0x")) substring(2) else this
+    val cleanInput = this.clean0xPrefix()
     val evenInput = if (cleanInput.length % 2 != 0) "0$cleanInput" else cleanInput
 
     return ByteArray(evenInput.length / 2).apply {
@@ -16,5 +16,5 @@ fun String.hexToByteArrayLenient(): ByteArray {
     }
 }
 
-internal fun String.clean0xPrefix(): String =
+fun String.clean0xPrefix(): String =
     if (this.startsWith("0x")) this.substring(2) else this

--- a/mnid/src/main/java/me/uport/mnid/HexFun.kt
+++ b/mnid/src/main/java/me/uport/mnid/HexFun.kt
@@ -1,5 +1,7 @@
 package me.uport.mnid
 
+import org.komputing.khex.extensions.clean0xPrefix
+
 fun String.hexToByteArrayLenient(): ByteArray {
     val cleanInput = this.clean0xPrefix()
     val evenInput = if (cleanInput.length % 2 != 0) "0$cleanInput" else cleanInput
@@ -15,6 +17,3 @@ fun String.hexToByteArrayLenient(): ByteArray {
         }
     }
 }
-
-fun String.clean0xPrefix(): String =
-    if (this.startsWith("0x")) this.substring(2) else this

--- a/mnid/src/main/java/me/uport/mnid/MNID.kt
+++ b/mnid/src/main/java/me/uport/mnid/MNID.kt
@@ -47,7 +47,7 @@ object MNID {
      */
     @Throws(MnidEncodingException::class)
     fun decode(mnid: String?): Account {
-        if (mnid == null || mnid.isEmpty()) {
+        if (mnid.isNullOrBlank()) {
             throw MnidEncodingException("Can't decode a null or empty mnid")
         }
 

--- a/mnid/src/test/java/me/uport/mnid/AccountTest.kt
+++ b/mnid/src/test/java/me/uport/mnid/AccountTest.kt
@@ -20,4 +20,26 @@ class AccountTest {
     fun throwsOnWeirdCharacters() {
         Account.from("2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexlIO0")
     }
+
+    @Test
+    fun `can create account from mnid`() {
+        val expected = Account("0x01", "0x0000000000000000000000000000000000001234")
+        val acc = Account.from("2nQs23uc3UN6BBPqGHpbudDxBkeNVX7YRBb")
+        assertEquals(expected, acc)
+    }
+
+    @Test(expected = MnidEncodingException::class)
+    fun `throws when given invalid address`() {
+        Account.from("0x01", "0x00000000000000000000000000000000000012345678")
+    }
+
+    @Test(expected = NullPointerException::class)
+    fun `throws when given null network`() {
+        Account.from(null, "0x0000000000000000000000000000000000001234")
+    }
+
+    @Test(expected = NullPointerException::class)
+    fun `throws when given null address`() {
+        Account.from("0x1", null)
+    }
 }

--- a/mnid/src/test/java/me/uport/mnid/MNIDTest.kt
+++ b/mnid/src/test/java/me/uport/mnid/MNIDTest.kt
@@ -77,7 +77,6 @@ class MNIDTest {
         assertEquals(direct, acc)
     }
 
-
     @Test
     fun decodeRopsten() {
         val decoded = MNID.decode("2oDZvNUgn77w2BKTkd9qKpMeUo8EL94QL5V")
@@ -151,7 +150,6 @@ class MNIDTest {
 
     }
 
-
     @Test
     fun isMnidValid() {
         assertTrue(MNID.isMNID("2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX"))
@@ -180,6 +178,26 @@ class MNIDTest {
 
         assertFalse(MNID.isMNID(""))
         assertFalse(MNID.isMNID(null))
+    }
+
+    @Test(expected = MnidEncodingException::class)
+    fun `throws on null input`() {
+        MNID.decode(null)
+    }
+
+    @Test(expected = MnidEncodingException::class)
+    fun `throws on empty input`() {
+        MNID.decode("")
+    }
+
+    @Test(expected = MnidEncodingException::class)
+    fun `throws on blank input`() {
+        MNID.decode(" ")
+    }
+
+    @Test
+    fun `encodes blank mnid when given null input`() {
+        assertEquals("2n1XR4oJkmBdJMxhBGQGb96gQ88xV6zpStY", MNID.encode(null))
     }
 
 }


### PR DESCRIPTION
This is a maintenance PR

* use library methods instead of rewriting them
* increase code coverage

**Note** to promote error checks, the `Account` constructor has been made `internal` so this will be followed by a major version release.