### PR TITLE
[support] replace java.nio.ByteBuffer with kotlinx.io.ByteBuffer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     ext {
         //general
         kotlin_version = '1.3.50'
+        serialization_version = '0.12.0'
 
         junit_version = "4.12"
         jacoco_version = "0.8.4"

--- a/mnid/build.gradle
+++ b/mnid/build.gradle
@@ -6,6 +6,8 @@ apply plugin: "java-library"
 dependencies {
     //noinspection DifferentStdlibGradleVersion
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$serialization_version"
+
     implementation "com.github.komputing.KEthereum:base58:$kethereum_version"
     implementation "com.github.komputing.KEthereum:hashes:$kethereum_version"
     implementation "com.github.komputing:KHash:$khash_version"

--- a/mnid/src/main/java/me/uport/mnid/MNID.kt
+++ b/mnid/src/main/java/me/uport/mnid/MNID.kt
@@ -1,8 +1,8 @@
 package me.uport.mnid
 
+import kotlinx.io.ByteBuffer
 import org.kethereum.encodings.decodeBase58
 import org.kethereum.encodings.encodeToBase58String
-import java.nio.ByteBuffer
 
 /**
  * Multi Network Identifier
@@ -37,6 +37,14 @@ object MNID {
     private const val ADDRESS_WIDTH = 20
     private const val CHECKSUM_WIDTH = 4
     private const val VERSION: Byte = 1
+
+    private fun ByteBuffer.get(out: ByteArray): Unit = this.get(out, 0, out.size)
+    private fun ByteBuffer.rewind() : ByteBuffer {
+        val backup = this.array()
+        return this.clear().put(backup).flip()
+    }
+    private fun ByteBuffer.Companion.wrap(input: ByteArray): ByteBuffer =
+        allocate(input.size).put(input).flip()
 
     /**
      * Decodes a MNID encoded address into an address and network.
@@ -133,8 +141,9 @@ object MNID {
         buff.put(addressBytes)
 
         //checksum
-        val payload = buff.array()
-            .sliceArray(0 until (buff.capacity() - CHECKSUM_WIDTH))
+        val payload = buff.array().run {
+            this.sliceArray(0 until (this.size - CHECKSUM_WIDTH))
+        }
         val hash = payload.sha3()
         val checksumBytes = hash.sliceArray(0 until CHECKSUM_WIDTH)
         buff.put(checksumBytes)

--- a/mnid/src/test/java/me/uport/mnid/Base58Test.kt
+++ b/mnid/src/test/java/me/uport/mnid/Base58Test.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.kethereum.encodings.decodeBase58
 import org.kethereum.encodings.encodeToBase58String
 import org.komputing.khex.extensions.hexToByteArray
-import java.util.*
+import java.util.Random
 
 class Base58Test {
 

--- a/mnid/src/test/java/me/uport/mnid/MNIDTest.kt
+++ b/mnid/src/test/java/me/uport/mnid/MNIDTest.kt
@@ -1,6 +1,9 @@
 package me.uport.mnid
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MNIDTest {
@@ -98,7 +101,7 @@ class MNIDTest {
         } catch (e: Exception) {
 
             assert(e is MnidEncodingException)
-            assertEquals(e.message, "The checksum does not match the payload")
+            assertEquals("The checksum does not match the payload", e.message)
         }
 
     }
@@ -115,8 +118,8 @@ class MNIDTest {
         } catch (e: Exception) {
             assert(e is MnidEncodingException)
             assertEquals(
-                e.message,
-                "Version mismatch.\nCan't decode a future version of MNID. Expecting 1 and got 2"
+                "Version mismatch.\nCan't decode a future version of MNID. Expecting 1 and got 2",
+                e.message
             )
         }
 
@@ -129,8 +132,8 @@ class MNIDTest {
         } catch (e: Exception) {
             assert(e is MnidEncodingException)
             assertEquals(
-                e.message,
-                "Buffer size mismatch.\nThere are not enough bytes in this mnid to encode an address"
+                "Buffer size mismatch.\nThere are not enough bytes in this mnid to encode an address",
+                e.message
             )
         }
 
@@ -143,8 +146,8 @@ class MNIDTest {
         } catch (e: Exception) {
             assert(e is MnidEncodingException)
             assertEquals(
-                e.message,
-                "Address is too long.\nAn Ethereum address must be 20 bytes long."
+                "Address is too long.\nAn Ethereum address must be 20 bytes long.",
+                e.message
             )
         }
 


### PR DESCRIPTION
This PR removes the last direct java dependency from the production code in this repo, preparing it for multiplatform support.

All the tests were kept and all pass, so there is no change to functionality.