### PR TITLE
fix: use implementation for deps to try to add them to pom

### DIFF
--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -31,15 +31,7 @@ android {
     }
 
     packagingOptions {
-        pickFirst 'META-INF/kotlinx-io.kotlin_module'
-        pickFirst 'META-INF/atomicfu.kotlin_module'
-        pickFirst 'META-INF/kbignumbers.kotlin_module'
-        pickFirst 'META-INF/ripemd160.kotlin_module'
-        pickFirst 'META-INF/extensions.kotlin_module'
-        pickFirst 'META-INF/core.kotlin_module'
-        pickFirst 'META-INF/keccak.kotlin_module'
-        pickFirst 'META-INF/sha256.kotlin_module'
-        pickFirst 'META-INF/khash-extensions.kotlin_module'
+        pickFirst 'META-INF/*.kotlin_module'
     }
 }
 
@@ -51,7 +43,7 @@ dependencies {
 
 
     //this needs to be added to your project
-    implementation "com.github.uport-project:kmnid:0.4.0"
+    implementation "com.github.uport-project:kmnid:0.4.3"
 //    implementation project(":mnid")
 
     testImplementation "junit:junit:$junit_version"

--- a/demoapp/src/test/java/me/uport/mnid/demo/MnidActivityTest.kt
+++ b/demoapp/src/test/java/me/uport/mnid/demo/MnidActivityTest.kt
@@ -1,5 +1,7 @@
 package me.uport.mnid.demo
 
+import me.uport.mnid.Account
+import org.junit.Assert
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -8,6 +10,13 @@ class MnidActivityTest {
     @Test
     fun `can run test`() {
         assertTrue(true)
+    }
+
+    @Test
+    fun `can use library`() {
+        val expected = Account.from("0x01", "0x0000000000000000000000000000000000001234")
+        val acc = Account.from("2nQs23uc3UN6BBPqGHpbudDxBkeNVX7YRBb")
+        Assert.assertEquals(expected, acc)
     }
 
 }

--- a/mnid/build.gradle
+++ b/mnid/build.gradle
@@ -8,9 +8,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$serialization_version"
 
-    api "com.github.komputing:kbase58:$kbase58_version"
-    api "com.github.komputing:khash:$khash_version"
-    api "com.github.komputing.khex:extensions:$khex_version"
+    implementation "com.github.komputing:kbase58:$kbase58_version"
+    implementation "com.github.komputing:khash:$khash_version"
+    implementation "com.github.komputing.khex:extensions:$khex_version"
 
     testImplementation "junit:junit:$junit_version"
 }


### PR DESCRIPTION
this apparently fixes the POM which does not get properly generated when using `api` leading to NoClassDefFound errors downstream